### PR TITLE
Default source file encoding in Python 2 is ASCII

### DIFF
--- a/src/rapidfuzz/process.py
+++ b/src/rapidfuzz/process.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
-# Copyright © 2020 Max Bachmann
-# Copyright © 2011 Adam Cohen
+# Copyright 2020 Max Bachmann
+# Copyright 2011 Adam Cohen
 
 from rapidfuzz import fuzz, utils
 from rapidfuzz.cpp_impl import extractOne

--- a/src/rapidfuzz/process.py
+++ b/src/rapidfuzz/process.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
-# Copyright 2020 Max Bachmann
-# Copyright 2011 Adam Cohen
+# Copyright (C) 2020 Max Bachmann
+# Copyright (C) 2011 Adam Cohen
 
 from rapidfuzz import fuzz, utils
 from rapidfuzz.cpp_impl import extractOne


### PR DESCRIPTION
We're experiencing the following error with Python 2.7:
```SyntaxError: Non-ASCII character '\xc2' in file <...>/rapidfuzz/process.py on line 2, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details```

In Python 3 it's UTF-8 by default so this probably doesn't cause problems: https://www.python.org/dev/peps/pep-3120/

If you want to keep the symbol, an alternative is to set an encoding on the file as per PEP-0263. But just making the file ASCII was easier for our testing.

Note we didn't experience this on most environments, i.e. our Mac and Linux development environments didn't error, probably due to the system default encoding there vs our CI/prod environments.

(Apologies for slightly messing around with your copyright header.)