### PR TITLE
chore: cibuildwheel is now part of the pypa

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: 'true'
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.10.0
+        uses: pypa/cibuildwheel@v1.12.0
         with:
           output-dir: wheelhouse
 
@@ -51,7 +51,7 @@ jobs:
           submodules: 'true'
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.10.0
+        uses: pypa/cibuildwheel@v1.12.0
         with:
           output-dir: wheelhouse
 
@@ -85,7 +85,7 @@ jobs:
         name: Set up QEMU
 
       - name: Build wheel
-        uses: joerick/cibuildwheel@v1.10.0
+        uses: pypa/cibuildwheel@v1.12.0
         with:
           output-dir: wheelhouse
 
@@ -116,7 +116,7 @@ jobs:
           submodules: 'true'
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.10.0
+        uses: pypa/cibuildwheel@v1.12.0
         with:
           output-dir: wheelhouse
 


### PR DESCRIPTION
Be sure to checkout cibuildwheel 2.0's new config options when it comes out; you can set static values in your pyproject.toml file in 2.0!