### PR TITLE
Move `py.typed`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,8 @@ include README.md
 include VERSION
 include LICENSE
 include pyproject.toml
-include py.typed
 include src/rapidfuzz/*.pyi
+include src/rapidfuzz/py.typed
 recursive-include src/rapidfuzz-cpp/rapidfuzz *.hpp *.h *.txx *cpp
 exclude src/rapidfuzz-cpp/rapidfuzz/process.hpp
 exclude src/rapidfuzz-cpp/rapidfuzz/process.txx


### PR DESCRIPTION
`py.typed` should be placed in the package folder (see PEP 561).