### PR TITLE
Fix minor issues with type annotations

### DIFF
--- a/src/rapidfuzz/fuzz.pyi
+++ b/src/rapidfuzz/fuzz.pyi
@@ -11,7 +11,7 @@ def ratio(
 
 def partial_ratio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]]], _StringType],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def token_sort_ratio(

--- a/src/rapidfuzz/fuzz.pyi
+++ b/src/rapidfuzz/fuzz.pyi
@@ -6,50 +6,50 @@ S2 = TypeVar("S2")
 
 def ratio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def partial_ratio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def token_sort_ratio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def token_set_ratio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def token_ratio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def partial_token_sort_ratio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def partial_token_set_ratio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def partial_token_ratio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def WRatio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def QRatio(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...

--- a/src/rapidfuzz/string_metric.pyi
+++ b/src/rapidfuzz/string_metric.pyi
@@ -7,36 +7,36 @@ S2 = TypeVar("S2")
 def levenshtein(
     s1: S1, s2: S2, *,
     weights: Optional[Tuple[int, int, int]] = (1,1,1),
-    processor: Optional[Callable[[Union[S1, S2]]], _StringType],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
     max: Optional[int] = None) -> int: ...
 
 def normalized_levenshtein(
     s1: S1, s2: S2, *,
     weights: Optional[Tuple[int, int, int]] = (1,1,1),
-    processor: Optional[Callable[[Union[S1, S2]]], _StringType],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def levenshtein_editops(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]]], _StringType]) -> List[Tuple[str, int, int]]: ...
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]]) -> List[Tuple[str, int, int]]: ...
 
 def hamming(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]]], _StringType],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
     max: Optional[int] = None) -> int: ...
 
 def normalized_hamming(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]]], _StringType],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def jaro_similarity(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]]], _StringType],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def jaro_winkler_similarity(
     s1: S1, s2: S2, *,
     prefix_weight: float = 0.1,
-    processor: Optional[Callable[[Union[S1, S2]]], _StringType],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
     score_cutoff: Optional[float] = 0) -> float: ...

--- a/src/rapidfuzz/string_metric.pyi
+++ b/src/rapidfuzz/string_metric.pyi
@@ -7,36 +7,36 @@ S2 = TypeVar("S2")
 def levenshtein(
     s1: S1, s2: S2, *,
     weights: Optional[Tuple[int, int, int]] = (1,1,1),
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     max: Optional[int] = None) -> int: ...
 
 def normalized_levenshtein(
     s1: S1, s2: S2, *,
     weights: Optional[Tuple[int, int, int]] = (1,1,1),
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def levenshtein_editops(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]]) -> List[Tuple[str, int, int]]: ...
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...) -> List[Tuple[str, int, int]]: ...
 
 def hamming(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     max: Optional[int] = None) -> int: ...
 
 def normalized_hamming(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def jaro_similarity(
     s1: S1, s2: S2, *,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...
 
 def jaro_winkler_similarity(
     s1: S1, s2: S2, *,
     prefix_weight: float = 0.1,
-    processor: Optional[Callable[[Union[S1, S2]], _StringType]],
+    processor: Optional[Callable[[Union[S1, S2]], _StringType]] = ...,
     score_cutoff: Optional[float] = 0) -> float: ...

--- a/src/rapidfuzz/string_metric.pyi
+++ b/src/rapidfuzz/string_metric.pyi
@@ -1,4 +1,4 @@
-from typing import Callable, Hashable, Sequence, Optional, Union, TypeVar, Tuple
+from typing import Callable, Hashable, Sequence, Optional, Union, TypeVar, Tuple, List
 
 _StringType = Sequence[Hashable]
 S1 = TypeVar("S1")


### PR DESCRIPTION
Version 1.8.3 introduced some minor issues with the type annotations provided with the library. I have fixed the ones I immediately could find here.

They are split into separate commits so it's easier to review.