### PR TITLE
generate cython code for LCSseq

### DIFF
--- a/rapidfuzz/generate.sh
+++ b/rapidfuzz/generate.sh
@@ -16,4 +16,5 @@ generate_cython cpp_utils
 generate_cython distance/_initialize
 generate_cython distance/Hamming
 generate_cython distance/Indel
+generate_cython distance/LCSseq
 generate_cython distance/Levenshtein


### PR DESCRIPTION
Version 2.0.8 sdist is missing the generated cython code `distance/LCSseq.cxx`.