### PR TITLE
Fix package data inclusion rules

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,9 +4,8 @@ include CMakeLists.txt
 include README.md
 include LICENSE
 include pyproject.toml
-include src/rapidfuzz/*.pyi
-include src/rapidfuzz/**/*.pyi
 include src/rapidfuzz/py.typed
+recursive-include src/rapidfuzz *.pyi
 
 recursive-include src/rapidfuzz CMakeLists.txt
 recursive-include src/rapidfuzz *.hpp *.h *.cpp *.cxx *.pyx *.pxd

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup_args = {
     "packages": ["rapidfuzz", "rapidfuzz.distance"],
     "package_dir": {
         'rapidfuzz': 'src/rapidfuzz',
-        "rapidfuzz.distance": 'src/rapidfuzz/distance'
     },
     "package_data": {
         "rapidfuzz": ["*.pyi", "py.typed"],

--- a/setup.py
+++ b/setup.py
@@ -32,14 +32,14 @@ setup_args = {
         "License :: OSI Approved :: MIT License"
     ],
 
-    "packages": ["rapidfuzz", "rapidfuzz/distance"],
+    "packages": ["rapidfuzz", "rapidfuzz.distance"],
     "package_dir": {
         'rapidfuzz': 'src/rapidfuzz',
-        "rapidfuzz/distance": 'src/rapidfuzz/distance'
+        "rapidfuzz.distance": 'src/rapidfuzz/distance'
     },
     "package_data": {
-        "src/rapidfuzz": ["*.pyi", "py.typed"],
-        "src/rapidfuzz/distance": ["*.pyi"]
+        "rapidfuzz": ["*.pyi", "py.typed"],
+        "rapidfuzz.distance": ["*.pyi"]
     },
     "python_requires": ">=3.6"
 }

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup_args = {
 
     "packages": ["rapidfuzz", "rapidfuzz.distance"],
     "package_dir": {
-        'rapidfuzz': 'src/rapidfuzz',
+        '': 'src',
     },
     "package_data": {
         "rapidfuzz": ["*.pyi", "py.typed"],


### PR DESCRIPTION
2.1.2 was missing the type definitions.