### PR TITLE
tests: handle missing pandas gracefully

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -5,7 +5,6 @@ import unittest
 import pytest
 
 from rapidfuzz import process_py, process_cpp, fuzz
-import pandas as pd
 
 
 class process:
@@ -298,6 +297,7 @@ class ProcessTest(unittest.TestCase):
 
     def testIssue81(self):
         # this mostly tests whether this segfaults due to incorrect ref counting
+        pd = pytest.importorskip("pandas")
         choices = pd.Series(
             ["test color brightness", "test lemon", "test lavender"],
             index=[67478, 67479, 67480],


### PR DESCRIPTION
Pandas is not yet ready for Python 3.11.  Use pytest.importorskip() to skip that one regression test that requires it when it's not available to unblock rapidfuzz on py3.11 on Gentoo.