### PR TITLE
chore: minor CMake cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ endif()
 
 find_package(PythonExtensions REQUIRED)
 if(CMAKE_VERSION VERSION_LESS 3.18)
-    find_package(Python COMPONENTS Interpreter Development)
+    find_package(Python COMPONENTS Interpreter Development REQUIRED)
 else()
-    find_package(Python COMPONENTS Interpreter Development.Module)
+    find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 endif()
 
 include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,8 @@
-cmake_minimum_required(VERSION 3.12.0)
+cmake_minimum_required(VERSION 3.12...3.24)
 
-cmake_policy(SET CMP0054 NEW)
 set(SKBUILD_LINK_LIBRARIES_KEYWORD PRIVATE)
-
+set(Python_FIND_IMPLEMENTATIONS CPython PyPy)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
-endif()
 
 project(rapidfuzz LANGUAGES C CXX)
 
@@ -17,16 +13,21 @@ else()
 endif()
 
 find_package(PythonExtensions REQUIRED)
-find_package(Python COMPONENTS Interpreter Development)
+if(CMAKE_VERSION VERSION_LESS 3.18)
+    find_package(Python COMPONENTS Interpreter Development)
+else()
+    find_package(Python COMPONENTS Interpreter Development.Module)
+endif()
+
 include(FetchContent)
 
 set(RF_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 find_package(Taskflow 3.0.0 QUIET)
 if (Taskflow_FOUND)
-    message("Using system supplied version of Taskflow")
+    message(STATUS "Using system supplied version of Taskflow")
 else()
-    message("Using packaged version of Taskflow")
+    message(STATUS "Using packaged version of Taskflow")
     set(TF_BUILD_CUDA OFF CACHE BOOL "Enables build of CUDA code")
     set(TF_BUILD_TESTS OFF CACHE BOOL "Enables build of tests")
     set(TF_BUILD_EXAMPLES OFF CACHE BOOL "Enables build of examples")
@@ -36,9 +37,9 @@ endif()
 
 find_package(rapidfuzz 1.7.0 QUIET)
 if (rapidfuzz_FOUND)
-    message("Using system supplied version of rapidfuzz-cpp")
+    message(STATUS "Using system supplied version of rapidfuzz-cpp")
 else()
-    message("Using packaged version of rapidfuzz-cpp")
+    message(STATUS "Using packaged version of rapidfuzz-cpp")
     add_subdirectory(extern/rapidfuzz-cpp)
 endif()
 


### PR DESCRIPTION
These are some minor cleanups from #256 that should be pretty safe. This does not include the switch to pure FindPython.
