### PR TITLE
Don't ship rapidfuzz.h

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup_args = {
         "": "src",
     },
     "package_data": {
-        "rapidfuzz": ["*.pyi", "py.typed", "__init__.pxd", "rapidfuzz.h"],
+        "rapidfuzz": ["*.pyi", "py.typed", "__init__.pxd"],
         "rapidfuzz.distance": ["*.pyi"],
     },
     "python_requires": ">=3.7",


### PR DESCRIPTION
While packaging rapidfuzz into Fedora we discovered that rapidfuzz.h is needed only during the build. I suggest removing it as there is no benefit in shipping this file to the user.