### PR TITLE
update pylint config for old pip versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,4 @@ testpaths = ["tests"]
 [tool.pylint]
 master.py-version = "3.6"
 reports.output-format = "colorized"
-messages_control.disable = [
-  "design",
-  "fixme",
-  "imports",
-  "line-too-long",
-  "imports",
-  "invalid-name",
-  "protected-access",
-  "missing-module-docstring",
-]
+messages_control.disable = ["design"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ xfail_strict = true
 log_cli_level = "info"
 testpaths = ["tests"]
 
-[tool.pylint]
-master.py-version = "3.6"
+[tool.pylint.master]
+py-version = "3.6"
 
-[tool.pylint.'REPORTS']
+[tool.pylint.reports]
 output-format = "colorized"
 
-[tool.pylint.'MESSAGES CONTROL']
+[tool.pylint.messages_control]
 disable = ["design"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,6 @@ testpaths = ["tests"]
 [tool.pylint]
 master.py-version = "3.6"
 reports.output-format = "colorized"
-messages_control.disable = ["design"]
+
+[tool.pylint.'MESSAGES CONTROL']
+disable = ["design"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,13 @@ py-version = "3.6"
 output-format = "colorized"
 
 [tool.pylint.messages_control]
-disable = ["design"]
+disable = [
+  "design",
+  "fixme",
+  "imports",
+  "line-too-long",
+  "imports",
+  "invalid-name",
+  "protected-access",
+  "missing-module-docstring",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ testpaths = ["tests"]
 
 [tool.pylint]
 master.py-version = "3.6"
-reports.output-format = "colorized"
+
+[tool.pylint.'REPORTS']
+output-format = "colorized"
 
 [tool.pylint.'MESSAGES CONTROL']
 disable = ["design"]


### PR DESCRIPTION
@henryiii I followed your guide in https://scikit-hep.org/developer/style#pylint-noisy to configure pylint in the `pyproject.toml`. This breaks when people use relatively old versions of pip. E.g. on debian bust:
```
apt-get install python3-pip
```
installs pip version 18.1, which is unable to parse this and fails with:
```
pytoml.core.TomlError: /tmp/pip-install-foysvdsk/rapidfuzz/pyproject.toml(30, 7): expected_equals
```