### PR TITLE
Fix mistakes in rapidfuzz.process docs

### DIFF
--- a/src/rapidfuzz/process_py.py
+++ b/src/rapidfuzz/process_py.py
@@ -304,11 +304,11 @@ def extractOne(
 
     It is possible to specify a processor function which is used to preprocess the strings before comparing them.
 
-    >>> extractOne("abcd", ["abdD"], scorer=ratio)
+    >>> extractOne("abcd", ["abcD"], scorer=ratio)
     ("abcD", 75.0, 0)
-    >>> extractOne("abcd", ["abdD"], scorer=ratio, processor=utils.default_process)
+    >>> extractOne("abcd", ["abcD"], scorer=ratio, processor=utils.default_process)
     ("abcD", 100.0, 0)
-    >>> extractOne("abcd", ["abdD"], scorer=ratio, processor=lambda s: s.upper())
+    >>> extractOne("abcd", ["abcD"], scorer=ratio, processor=lambda s: s.upper())
     ("abcD", 100.0, 0)
 
     When only results with a similarity above a certain threshold are relevant, the parameter score_cutoff can be

--- a/src/rapidfuzz/process_py.py
+++ b/src/rapidfuzz/process_py.py
@@ -100,9 +100,9 @@ def extract_iter(
         comparing them. Default is None, which deactivates this behaviour.
     score_cutoff : Any, optional
         Optional argument for a score threshold. When an edit distance is used this represents the maximum
-        edit distance and matches with a `distance <= score_cutoff` are ignored. When a
+        edit distance and matches with a `distance > score_cutoff` are ignored. When a
         normalized edit distance is used this represents the minimal similarity
-        and matches with a `similarity >= score_cutoff` are ignored. Default is None, which deactivates this behaviour.
+        and matches with a `similarity < score_cutoff` are ignored. Default is None, which deactivates this behaviour.
     score_hint : Any, optional
         Optional argument for an expected score to be passed to the scorer.
         This is used to select a faster implementation. Default is None,
@@ -235,9 +235,9 @@ def extractOne(
         comparing them. Default is None, which deactivates this behaviour.
     score_cutoff : Any, optional
         Optional argument for a score threshold. When an edit distance is used this represents the maximum
-        edit distance and matches with a `distance <= score_cutoff` are ignored. When a
+        edit distance and matches with a `distance > score_cutoff` are ignored. When a
         normalized edit distance is used this represents the minimal similarity
-        and matches with a `similarity >= score_cutoff` are ignored. Default is None, which deactivates this behaviour.
+        and matches with a `similarity < score_cutoff` are ignored. Default is None, which deactivates this behaviour.
     score_hint : Any, optional
         Optional argument for an expected score to be passed to the scorer.
         This is used to select a faster implementation. Default is None,
@@ -442,9 +442,9 @@ def extract(
         maximum amount of results to return
     score_cutoff : Any, optional
         Optional argument for a score threshold. When an edit distance is used this represents the maximum
-        edit distance and matches with a `distance <= score_cutoff` are ignored. When a
+        edit distance and matches with a `distance > score_cutoff` are ignored. When a
         normalized edit distance is used this represents the minimal similarity
-        and matches with a `similarity >= score_cutoff` are ignored. Default is None, which deactivates this behaviour.
+        and matches with a `similarity < score_cutoff` are ignored. Default is None, which deactivates this behaviour.
     score_hint : Any, optional
         Optional argument for an expected score to be passed to the scorer.
         This is used to select a faster implementation. Default is None,

--- a/src/rapidfuzz/process_py.py
+++ b/src/rapidfuzz/process_py.py
@@ -122,7 +122,7 @@ def extract_iter(
         * The second value represents the similarity calculated by the scorer. This can be:
 
           * An edit distance (distance is 0 for a perfect match and > 0 for non perfect matches).
-            In this case only choices which have a `distance <= max` are yielded.
+            In this case only choices which have a `distance <= score_cutoff` are yielded.
             An example of a scorer with this behavior is `Levenshtein.distance`.
           * A normalized edit distance (similarity is a score between 0 and 100, with 100 being a perfect match).
             In this case only choices which have a `similarity >= score_cutoff` are yielded.
@@ -464,7 +464,7 @@ def extract(
         * The second value represents the similarity calculated by the scorer. This can be:
 
           * An edit distance (distance is 0 for a perfect match and > 0 for non perfect matches).
-            In this case only choices which have a `distance <= max` are returned.
+            In this case only choices which have a `distance <= score_cutoff` are returned.
             An example of a scorer with this behavior is `Levenshtein.distance`.
           * A normalized edit distance (similarity is a score between 0 and 100, with 100 being a perfect match).
             In this case only choices which have a `similarity >= score_cutoff` are returned.
@@ -477,7 +477,7 @@ def extract(
           * The `index of choice` when choices is a simple iterable like a list
           * The `key of choice` when choices is a mapping like a dict, or a pandas Series
 
-        The list is sorted by `score_cutoff` or `max` depending on the scorer used. The first element in the list
+        The list is sorted by similarity or distance depending on the scorer used. The first element in the list
         has the `highest similarity`/`smallest distance`.
 
     """


### PR DESCRIPTION
Hello,

As I was reading a part of the documentation I stumbled upon a couple of minor mistakes and this is a PR to fix them. You can find a detailed description in the commit messages.

Also, are these 3 references to `max` outdated?
https://github.com/maxbachmann/RapidFuzz/blob/c8be9093320bedcd1d75a816b6a554233074db78/src/rapidfuzz/process_py.py#L125
https://github.com/maxbachmann/RapidFuzz/blob/c8be9093320bedcd1d75a816b6a554233074db78/src/rapidfuzz/process_py.py#L467
https://github.com/maxbachmann/RapidFuzz/blob/c8be9093320bedcd1d75a816b6a554233074db78/src/rapidfuzz/process_py.py#L480 
If they are I can push an extra commit in this PR to replace them with `score_cutoff`.

Thanks for maintaining this useful project!