### PR TITLE
Sphinx conf.py fix and improvement

### DIFF
--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: artifact-${{ strategy.job-index }}
+          name: artifact-${{ github.job }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_wheels_macos:
@@ -156,7 +156,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: artifact-${{ strategy.job-index }}
+          name: artifact-${{ github.job }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_wheels_linux:
@@ -211,7 +211,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: artifact-${{ strategy.job-index }}
+          name: artifact-${{ github.job }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   deploy-wheels:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ pygments_dark_style = "monokai"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 napoleon_google_docstring = False
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,8 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+from __future__ import annotations
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -16,8 +18,6 @@
 
 
 # -- Project information -----------------------------------------------------
-from __future__ import annotations
-
 import rapidfuzz
 
 project = "RapidFuzz"


### PR DESCRIPTION
Hi!
Two issues with the current sphinx config file:

- The `from __future__ import annotations` line appears after the comment about adding an explicit import path.  Uncommenting the import path breaks the configuration as the future import must be the first piece of code in a Python file.  So this PR moves the import to before the comment.
- The current version of sphinx on Debian (7.2.6) fails if `html_static_path` points to a non-existent location.  So this PR comments out the non-existing `_static` directory.  (This directory is still created by the sphinx build, though.)