### PR TITLE
Adds examples to token_set_ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Scorers in RapidFuzz can be found in the modules `fuzz` and `distance`.
 84.21052631578947
 > fuzz.token_set_ratio("fuzzy was a bear", "fuzzy fuzzy was a bear")
 100.0
+# Returns 100.0 if one string is a subset of the other, regardless of extra content in the longer string
+> fuzz.token_set_ratio("fuzzy was a bear but not a dog", "fuzzy was a bear")
+100.0
+# Score is reduced only when there is explicit disagreement in the two strings
+> fuzz.token_set_ratio("fuzzy was a bear but not a dog", "fuzzy was a bear but not a cat")
+92.3076923076923
 ```
 
 #### Weighted Ratio

--- a/src/rapidfuzz/fuzz_py.py
+++ b/src/rapidfuzz/fuzz_py.py
@@ -434,6 +434,12 @@ def token_set_ratio(
     83.8709716796875
     >>> fuzz.token_set_ratio("fuzzy was a bear", "fuzzy fuzzy was a bear")
     100.0
+    # Returns 100.0 if one string is a subset of the other, regardless of extra content in the longer string
+    >>> fuzz.token_set_ratio("fuzzy was a bear but not a dog", "fuzzy was a bear")
+    100.0
+    # Score is reduced only when there is explicit disagreement in the two strings
+    >>> fuzz.token_set_ratio("fuzzy was a bear but not a dog", "fuzzy was a bear but not a cat")
+    92.3076923076923
     """
     setupPandas()
     if is_none(s1) or is_none(s2):


### PR DESCRIPTION
I've added two examples to the `fuzz.token_set_ratio` docs: One showing if one string is a subset of the other, it will return 100.0 and the other showing a divergence from 100.0 when there is disagreement in the strings.

When I looked at the existing example: 
```python
>>> fuzz.token_set_ratio("fuzzy was a bear", "fuzzy fuzzy was a bear")    
100.0
```

It wasn't clear to me if the score of 100.0 was only due to the sets of the two tokenized strings being equivalent (with the repetition of "fuzzy" being eliminated in the set) or because one set was a subset of the other, so I added these examples to make this more explicit. 

Happy to make any adjustments if need be!