### PR TITLE
fix: pyproject.toml metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers=[
   "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: MIT License",
 ]
+
+[project.urls]
 Homepage = "https://github.com/rapidfuzz/RapidFuzz"
 Documentation = "https://rapidfuzz.github.io/RapidFuzz/"
 Repository = "https://github.com/rapidfuzz/RapidFuzz.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "scikit-build-core>=0.10.7",
+    "scikit-build-core>=0.11",
     "Cython >=3.0.11, <3.1.0"
 ]
 build-backend = "scikit_build_core.build"
@@ -14,6 +14,7 @@ authors = [
 ]
 description = "rapid fuzzy string matching"
 readme = "README.md"
+license = "MIT"
 classifiers=[
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",
@@ -21,7 +22,6 @@ classifiers=[
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "License :: OSI Approved :: MIT License",
 ]
 
 [project.urls]


### PR DESCRIPTION
Going through some build failures in `scikit-build-core 0.11` and patching them up.

In 0.11 PEP639 was introduced, and if you want to opt-in to it, you would need to replace the `License` in `classifiers` with `project.license` in SPDX format. Otherwise this patch should be sufficient

PS: are you tracking the Cython higher-bound somewhere?