### PR TITLE
PEP 621 compliant license configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "rapid fuzzy string matching"
 readme = "README.md"
-license = "MIT"
+license = {text= "MIT"}
 classifiers=[
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Configured the license to be compliant with PEP 621:

https://pdm-project.org/latest/reference/pep621/#license
https://peps.python.org/pep-0621/#license
https://python-poetry.org/docs/main/pyproject/#license