### PR TITLE
`import rapidfuzz` disables the GIL on free threaded Python 3.13t and 3.14t

### DIFF
--- a/.github/workflows/branchbuild.yml
+++ b/.github/workflows/branchbuild.yml
@@ -16,9 +16,9 @@ jobs:
         with:
           submodules: 'true'
 
-      - uses: "actions/setup-python@v5"
+      - uses: "actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14t"
 
       - name: Install dependencies
         run: |
@@ -52,9 +52,9 @@ jobs:
     steps:
       - uses: "actions/checkout@v5"
 
-      - uses: "actions/setup-python@v5"
+      - uses: "actions/setup-python@v6"
         with:
-          python-version: "3.13"
+          python-version: "3.14t"
 
       - name: Install rapidfuzz-cpp
         run: |
@@ -96,9 +96,9 @@ jobs:
     steps:
       - uses: "actions/checkout@v5"
 
-      - uses: "actions/setup-python@v5"
+      - uses: "actions/setup-python@v6"
         with:
-          python-version: "3.13"
+          python-version: "3.14t"
 
       - name: Install rapidfuzz-cpp
         run: |
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-14]
         exclude:
           - python-version: "3.10"
@@ -149,7 +149,7 @@ jobs:
       - uses: "actions/checkout@v5"
         with:
           submodules: 'true'
-      - uses: "actions/setup-python@v5"
+      - uses: "actions/setup-python@v6"
         with:
           allow-prereleases: true
           python-version: "${{ matrix.python-version }}"
@@ -185,7 +185,7 @@ jobs:
           python -m PyInstaller.utils.run_tests --include_only rapidfuzz.
 
       - name: test cx_freeze packaging
-        if: matrix.python-version != '3.13' && matrix.python-version != '3.13t'
+        if: matrix.python-version != '3.13' && matrix.python-version != '3.13t' && matrix.python-version != '3.14' && matrix.python-version != '3.14t' 
         working-directory: tests/freezeTools
         run: |
           pip install cx_freeze
@@ -206,9 +206,9 @@ jobs:
           repository: rapidfuzz/intel-sde
           path: sde
 
-      - uses: "actions/setup-python@v5"
+      - uses: "actions/setup-python@v6"
         with:
-          python-version: "3.13"
+          python-version: "3.14t"
 
       - name: build
         run: |

--- a/.github/workflows/branchbuild.yml
+++ b/.github/workflows/branchbuild.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: 'true'
 
-      - uses: "actions/setup-python@v6
+      - uses: "actions/setup-python@v6"
         with:
           python-version: "3.14t"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: "actions/checkout@v5"
         with:
           submodules: 'true'
-      - uses: "actions/setup-python@v5"
+      - uses: "actions/setup-python@v6"
         with:
-          python-version: "3.11"
+          python-version: "3.14t"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
% `uvx --with=rapidfuzz python3.14t -c "import rapidfuzz"`
```
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled
    to load module 'rapidfuzz.distance.metrics_cpp', which has not declared that it can run safely
    without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with
    PYTHON_GIL=0 or -Xgil=0.
```
---
https://www.python.org/downloads/release/python-3140/
* #399
* https://github.com/actions/setup-python/releases
    * #458

@maxbachmann

% `pytest ` # Tests pass, but the GIL is disabled.
```
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:491
  <frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled
    to load module 'rapidfuzz.distance.metrics_cpp', which has not declared that it can run safely
    without the GIL.  To override this behavior and keep the GIL disabled (at your own risk), run with
    PYTHON_GIL=0 or -Xgil=0.
```
* fsfe/reuse-tool#1265
