### PR TITLE
Upgrade from deprecated macos-13 to macos-15-intel in CI

### DIFF
--- a/.github/workflows/branchbuild.yml
+++ b/.github/workflows/branchbuild.yml
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t"]
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-15-intel, macos-14]
         exclude:
           - python-version: "3.10"
             os: windows-11-arm

--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-15-intel, macos-14]
     env:
       CIBW_TEST_SKIP: "pp*-macosx_*"
       CIBW_BUILD_VERBOSITY: 3


### PR DESCRIPTION
Replace GitHub Actions runner image `macos-13` with `macos-15-intel` as recommended in:
* https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down
> The macOS 13 runner image will be retired by ___December 4th, 2025___.

The currently available GitHub Actions macOS runners are:
| macOS Version | runner.arch |
|---------------|-------------|
| macos-13 | X64 |
| macos-14 | ARM64 |
| macos-15 | ARM64 |
| macos-15-intel | X64 |
| macos-26 | ARM64 |
| macos-latest | ARM64 |
