### PR TITLE
ci: add riscv64 wheel builds

### DIFF
--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -65,6 +65,9 @@ jobs:
             runs-on: ubuntu-latest
           - os: linux-arm
             runs-on: ubuntu-24.04-arm
+          - os: linux-riscv64
+            runs-on: ubuntu-latest
+            archs: riscv64
           - os: windows-intel
             runs-on: windows-latest
           - os: windows-arm
@@ -79,7 +82,7 @@ jobs:
           #  runs-on: ubuntu-latest
           #  platform: android
           #- os: android-arm
-          #  # GitHub Actions doesn’t currently support the Android emulator on any ARM
+          #  # GitHub Actions doesn't currently support the Android emulator on any ARM
           #  # runner. So we build on a non-ARM runner, which will skip the tests.
           #  runs-on: ubuntu-latest
           #  platform: android
@@ -100,6 +103,12 @@ jobs:
       - name: Copy wheel
         shell: bash
         run: cp dist/*.tar.gz rapidfuzz.tar.gz
+
+      - name: Set up QEMU
+        if: matrix.archs == 'riscv64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.0


### PR DESCRIPTION
## Summary

Add RISC-V 64-bit (riscv64) Linux wheel builds to the release workflow.

### Changes

- Add `linux-riscv64` matrix entry to `build_wheels` job in `releasebuild.yml`, using `ubuntu-latest` with `CIBW_ARCHS: riscv64`
- Add a conditional QEMU setup step (`docker/setup-qemu-action@v3`) that runs only for the riscv64 build, enabling cross-architecture wheel compilation via cibuildwheel

### How it works

cibuildwheel already supports riscv64 as a target architecture on Linux. The build runs on a standard x86_64 GitHub Actions runner with QEMU user-mode emulation providing the riscv64 environment. This follows the same pattern used by other Python projects (e.g., NumPy, SciPy) to produce riscv64 wheels.

### Testing

- The existing `test-command` in `pyproject.toml` (`pytest {package}/tests`) will run under QEMU as part of the cibuildwheel build
- No changes to test configuration needed

---

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms. Native riscv64 CI runners are available for free via [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners).