### PR TITLE
ci: switch riscv64 from QEMU to native RISE runner

### DIFF
--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -66,7 +66,7 @@ jobs:
           - os: linux-arm
             runs-on: ubuntu-24.04-arm
           - os: linux-riscv64
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-24.04-riscv
             archs: riscv64
           - os: windows-intel
             runs-on: windows-latest
@@ -104,13 +104,8 @@ jobs:
         shell: bash
         run: cp dist/*.tar.gz rapidfuzz.tar.gz
 
-      - name: Set up QEMU
-        if: matrix.archs == 'riscv64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: riscv64
-
       - name: Build wheels
+        if: matrix.archs != 'riscv64'
         uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
@@ -118,6 +113,15 @@ jobs:
         with:
           package-dir: rapidfuzz.tar.gz
           output-dir: wheelhouse
+
+      - name: Build wheels (riscv64 native)
+        if: matrix.archs == 'riscv64'
+        run: |
+          export PATH="$(ls -d /opt/python-3.1*/bin 2>/dev/null | sort -V | tail -1):$PATH"
+          python3 -m pip install pipx
+          pipx run cibuildwheel rapidfuzz.tar.gz --output-dir wheelhouse
+        env:
+          CIBW_ARCHS: riscv64
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Switch riscv64 wheel builds from QEMU emulation (~6h) to native RISE runners.

Changes:
- `runs-on: ubuntu-latest` + QEMU replaced with `runs-on: ubuntu-24.04-riscv` (native hardware)
- Removed docker/setup-qemu-action step
- Use `pipx run cibuildwheel` on riscv64 to bypass the GitHub Action's `setup-python` call (not yet available for riscv64)
- Other platforms unchanged

The RISE GitHub App is already installed on the rapidfuzz org.

Addresses the build time concern from #474.