### PR TITLE
ci: use pypa/cibuildwheel action directly for riscv64 native runner

### DIFF
--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -112,7 +112,6 @@ jobs:
         run: cp dist/*.tar.gz rapidfuzz.tar.gz
 
       - name: Build wheels
-        if: matrix.archs != 'riscv64'
         uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
@@ -120,15 +119,6 @@ jobs:
         with:
           package-dir: rapidfuzz.tar.gz
           output-dir: wheelhouse
-
-      - name: Build wheels (riscv64 native)
-        if: matrix.archs == 'riscv64'
-        run: |
-          export PATH="$(ls -d /opt/python-3.1*/bin 2>/dev/null | sort -V | tail -1):$PATH"
-          python3 -m pip install pipx
-          pipx run cibuildwheel rapidfuzz.tar.gz --output-dir wheelhouse
-        env:
-          CIBW_ARCHS: riscv64
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
The riscv64 build step was using a manual `run` block to invoke
cibuildwheel via pipx, with a glob to find Python under
`/opt/python-3.1*/bin`. That broke after the RISE riscv64 runner image
was rebuilt on 2026-04-22. The `/opt/python-3.12` paths are gone, the
glob finds nothing, PATH falls back to system Python 3.12, and
`pip install pipx` hits PEP 668 (Ubuntu 24.04 blocks system-level
installs without `--break-system-packages`).

The fix: use the `pypa/cibuildwheel` action directly, same as every
other architecture in this workflow. The action handles Python setup
internally and works fine on `ubuntu-24.04-riscv`.

I also dropped the `if: matrix.archs != 'riscv64'` guard on the Build
wheels step. One unified step now covers everything, which avoids the
two paths slowly diverging over time.

Tested on the RISE native riscv64 runner (`ubuntu-24.04-riscv`):
https://github.com/gounthar/RapidFuzz/actions/runs/25289792932