### PR TITLE
Changes to build ppc64le and s390x

### DIFF
--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -111,7 +111,13 @@ jobs:
         shell: bash
         run: cp dist/*.tar.gz rapidfuzz.tar.gz
 
+      - uses: IBM/setup-python-pz@291287e36d7c893a50c857d8bc014d67edd58ada
+        if: matrix.archs == 'ppc64le' || matrix.archs == 's390x'
+        with:
+          python-version: '3.11'
+
       - name: Build wheels
+        if: matrix.archs != 'ppc64le' && matrix.archs != 's390x'
         uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
@@ -119,6 +125,15 @@ jobs:
         with:
           package-dir: rapidfuzz.tar.gz
           output-dir: wheelhouse
+      
+      - name: Build Wheel (ppc64le and s390x)
+        if: matrix.archs == 'ppc64le' || matrix.archs =='s390x'
+        env:
+          CIBW_PLATFORM: linux
+          CIBW_ARCHS: ${{ matrix.archs }}
+        run: |
+          python -m pip install cibuildwheel==3.4.1
+          python -m cibuildwheel --output-dir wheelhouse rapidfuzz.tar.gz
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
This PR fixes the workflow to build ppc64le and s390x wheel files. 

I tried the changes on a self-hosted runner and was able to build the wheel. 
https://github.com/irapandey/RapidFuzz/actions/runs/25668496846/job/75347776163

This is a part of #481