### PR TITLE
docs: update outdated license comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 ## Description
 RapidFuzz is a fast string matching library for Python and C++, which is using the string similarity calculations from [FuzzyWuzzy](https://github.com/seatgeek/fuzzywuzzy). However there are a couple of aspects that set RapidFuzz apart from FuzzyWuzzy:
-1) It is MIT licensed so it can be used with whichever License you might want to choose for your project, while you're forced to adopt the GPL license when using FuzzyWuzzy
+1) It is MIT licensed so it can be used with whichever license you might want to choose for your project.
 2) It provides many string_metrics like hamming or jaro_winkler, which are not included in FuzzyWuzzy
 3) It is mostly written in C++ and on top of this comes with a lot of Algorithmic improvements to make string matching even faster, while still providing the same results. For detailed benchmarks check the [documentation](https://rapidfuzz.github.io/RapidFuzz)
 4) Fixes multiple bugs in the `partial_ratio` implementation


### PR DESCRIPTION
Fixes #424

The README referenced FuzzyWuzzy's GPL license as a differentiator.

Since thefuzz is MIT licensed and the issue discussion indicates this comparison is outdated, this change removes the outdated licensing comparison while keeping the MIT licensing information for RapidFuzz.
