### PR TITLE
Fix pure Python fallback divergences from the C++ implementation

### DIFF
--- a/src/rapidfuzz/distance/Jaro_py.py
+++ b/src/rapidfuzz/distance/Jaro_py.py
@@ -145,7 +145,8 @@ def similarity(
             if s1[i] != s2[j]:
                 trans_count += 1
 
-    return _jaro_calculate_similarity(pattern_len, text_len, common_chars, trans_count)
+    sim = _jaro_calculate_similarity(pattern_len, text_len, common_chars, trans_count)
+    return sim if sim >= score_cutoff else 0
 
 
 def normalized_similarity(

--- a/src/rapidfuzz/distance/LCSseq_py.py
+++ b/src/rapidfuzz/distance/LCSseq_py.py
@@ -182,7 +182,7 @@ def normalized_distance(
         s1 = processor(s1)
         s2 = processor(s2)
 
-    if not s1 or not s2:
+    if not s1 and not s2:
         return 0
 
     s1, s2 = conv_sequences(s1, s2)

--- a/src/rapidfuzz/fuzz_py.py
+++ b/src/rapidfuzz/fuzz_py.py
@@ -450,6 +450,9 @@ def token_set_ratio(
     if score_cutoff is None:
         score_cutoff = 0
 
+    if score_cutoff > 100:
+        return 0
+
     s1, s2 = conv_sequences(s1, s2)
 
     tokens_a = set(_split_sequence(s1))
@@ -641,6 +644,9 @@ def partial_token_set_ratio(
         s1 = processor(s1)
         s2 = processor(s2)
 
+    if score_cutoff is not None and score_cutoff > 100:
+        return 0
+
     s1, s2 = conv_sequences(s1, s2)
 
     tokens_a = set(_split_sequence(s1))
@@ -703,6 +709,9 @@ def partial_token_ratio(
 
     if score_cutoff is None:
         score_cutoff = 0
+
+    if score_cutoff > 100:
+        return 0
 
     s1, s2 = conv_sequences(s1, s2)
 
@@ -789,6 +798,9 @@ def WRatio(
 
     if score_cutoff is None:
         score_cutoff = 0
+
+    if score_cutoff > 100:
+        return 0
 
     len1 = len(s1)
     len2 = len(s2)

--- a/tests/distance/test_Jaro.py
+++ b/tests/distance/test_Jaro.py
@@ -47,6 +47,18 @@ def test_edge_case_lengths():
     assert pytest.approx(Jaro.similarity(s2, s1)) == 0.8359375
 
 
+def test_score_cutoff():
+    """
+    score_cutoff was not applied to the exact similarity in the pure Python
+    fallback when the coarse filters passed. The transpositions in "abcd"/"dcba"
+    place the exact similarity (0.5) below the coarse upper bound (0.66)
+    """
+    assert pytest.approx(Jaro.similarity("abcd", "dcba")) == 0.5
+    assert pytest.approx(Jaro.similarity("abcd", "dcba", score_cutoff=0.5)) == 0.5
+    assert Jaro.similarity("abcd", "dcba", score_cutoff=0.6) == 0.0
+    assert Jaro.normalized_similarity("abcd", "dcba", score_cutoff=0.6) == 0.0
+
+
 def testCaseInsensitive():
     assert pytest.approx(Jaro.similarity("new york mets", "new YORK mets", processor=utils_cpp.default_process)) == 1.0
     assert pytest.approx(Jaro.similarity("new york mets", "new YORK mets", processor=utils_py.default_process)) == 1.0

--- a/tests/distance/test_LCSseq.py
+++ b/tests/distance/test_LCSseq.py
@@ -10,6 +10,20 @@ def test_basic():
     assert LCSseq.distance("aaaa", "bbbb") == 4
 
 
+def test_empty_string():
+    """
+    the normalized results against a single empty string were inverted in the
+    pure Python fallback
+    """
+    assert LCSseq.distance("abc", "") == 3
+    assert LCSseq.normalized_distance("abc", "") == 1.0
+    assert LCSseq.normalized_similarity("abc", "") == 0.0
+    assert LCSseq.normalized_distance("abc", "", score_cutoff=0.5) == 1.0
+
+    assert LCSseq.normalized_distance("", "") == 0.0
+    assert LCSseq.normalized_similarity("", "") == 1.0
+
+
 def test_Editops():
     """
     basic test for LCSseq.editops

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -216,6 +216,42 @@ def test_issue196():
     assert fuzz.WRatio("South Korea", "North Korea", score_cutoff=85.5) == 0.0
 
 
+def test_wratio_score_cutoff():
+    """
+    WRatio returned scores below score_cutoff when its internally scaled
+    score_cutoff exceeded 100
+    """
+    assert fuzz.WRatio("b", " b daadabbb") == 60.0
+    assert fuzz.WRatio("b", " b daadabbb", score_cutoff=59.9) == 60.0
+    assert fuzz.WRatio("b", " b daadabbb", score_cutoff=61) == 0.0
+
+
+@pytest.mark.parametrize("impl", [fuzz_cpp, fuzz_py])
+@pytest.mark.parametrize(
+    "scorer_name",
+    [
+        "ratio",
+        "partial_ratio",
+        "token_sort_ratio",
+        "token_set_ratio",
+        "token_ratio",
+        "partial_token_sort_ratio",
+        "partial_token_set_ratio",
+        "partial_token_ratio",
+        "WRatio",
+        "QRatio",
+    ],
+)
+def test_score_cutoff_above_100(impl, scorer_name):
+    """
+    a score_cutoff above 100 can never be reached
+    """
+    scorer = getattr(impl, scorer_name)
+    assert scorer("abcd", "abcd") == 100.0
+    assert scorer("abcd", "abcd", score_cutoff=100) == 100.0
+    assert scorer("abcd", "abcd", score_cutoff=100.1) == 0.0
+
+
 def test_issue231():
     str1 = "er merkantilismus förderte handle und verkehr mit teils marktkonformen, teils dirigistischen maßnahmen."
     str2 = "ils marktkonformen, teils dirigistischen maßnahmen. an der schwelle zum 19. jahrhundert entstand ein neu"


### PR DESCRIPTION
The pure Python fallback (used on PyPy or when the C++ extension is unavailable) diverges from the C++ implementation in three places. All three were found by differential-fuzzing the two implementations against each other, and the regression tests run through the existing cpp/py parity test helpers.

**LCSseq: normalized results against one empty string are inverted**

```python
>>> from rapidfuzz.distance import LCSseq_py
>>> LCSseq_py.normalized_distance("abc", "")
0        # C++: 1.0
>>> LCSseq_py.normalized_similarity("abc", "")
1.0      # C++: 0.0
```

The zero-division guard in `normalized_distance` used `or` instead of `and`, so any comparison against a single empty string reported a perfect match.

**Jaro: score_cutoff is not applied to the exact similarity**

```python
>>> from rapidfuzz.distance import Jaro_py
>>> Jaro_py.similarity("abcd", "dcba", score_cutoff=0.6)
0.5      # C++: 0.0
```

`similarity` uses the cutoff in the two coarse upper bound filters, but the exact similarity computed afterwards was returned unfiltered. `JaroWinkler_py` already ends with `return Sim if Sim >= score_cutoff else 0`; `Jaro_py` now does the same.

**fuzz: token scorers are missing the `score_cutoff > 100` guard**

The C++ token scorers all start with `if (score_cutoff > 100) return 0;` (fuzz_impl.hpp). The Python ports don't, so their `return 100` early exits (common word in both sequences) ignore the cutoff. This becomes user-visible at ordinary cutoffs through `WRatio`, which scales its cutoff above 100 internally before calling them - so passing a cutoff can *change* the score instead of filtering it:

```python
>>> from rapidfuzz import fuzz_py
>>> fuzz_py.WRatio("b", " b daadabbb")
60.0
>>> fuzz_py.WRatio("b", " b daadabbb", score_cutoff=70)
57.0     # C++: 0.0
```

Added the guard to `token_set_ratio`, `partial_token_set_ratio`, `partial_token_ratio` and `WRatio`. The other scorers already inherit it from `ratio`/`partial_ratio`.

One related divergence I noticed but left alone since it's in the process layer: `process_py` doesn't reject `score_cutoff > 100` with a TypeError the way `process_cpp` does.
